### PR TITLE
fix: corrected signals for pin 16 and 19

### DIFF
--- a/Electrical/Pinouts.md
+++ b/Electrical/Pinouts.md
@@ -68,10 +68,10 @@ control.
 | 13  | EDP_TXN_1   |                        |
 | 14  | GND         |                        |
 | 15  | EDP_TXP_2   |                        |
-| 16  | EDP_TXN_3   |                        |
+| 16  | EDP_TXN_2   |                        |
 | 17  | GND         |                        |
 | 18  | EDP_TXP_3   |                        |
-| 19  | EDP_TXN_4   |                        |
+| 19  | EDP_TXN_3   |                        |
 | 20  | GND         |                        |
 | 21  | EDP_HPD     | hotplug                |
 | 22  | BLK_PWM_LCD | Backlight PWM          |


### PR DESCRIPTION
The schematic is in conflict with the pinouts markdown file

![unknown](https://user-images.githubusercontent.com/1551593/179417873-e438ca8d-c711-4fc8-b01e-cee10816bba0.png)

as such this PR makes the following changes:

* updates pin 16 from EDP lane 3 negative to the correct EDP lane 2 negative
* updates pin 19 from the EDP lane 4 negative (EDP only has 4 lanes currently so a lane ID 4 doesn't exist) to EDP lane 3 negative